### PR TITLE
[feat] SearchTextField 구현

### DIFF
--- a/FLINT/FLINT/Presentation/Common/Components/SearchTextField.swift
+++ b/FLINT/FLINT/Presentation/Common/Components/SearchTextField.swift
@@ -1,0 +1,103 @@
+//
+//  SearchTextField.swift
+//  FLINT
+//
+//  Created by 김호성 on 2026.01.08.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SearchTextField: UITextField {
+    
+    // MARK: - Property
+    
+    var searchAction: ((String?) -> Void)?
+    
+    // MARK: - Component
+    
+    private let actionButton = UIButton().then {
+        $0.setImage(.icSearch, for: .normal)
+    }
+    
+    // MARK: - Basic
+     
+    init(placeholder: String, searchAction: ((String?) -> Void)? = nil) {
+        self.searchAction = searchAction
+        super.init(frame: .zero)
+        
+        setUI()
+        setLayout()
+        setAction()
+        
+        applyFontStyle(.body1_r_16, textColor: .flintWhite)
+        self.placeholder = placeholder
+        applyPlaceholderFontStyle(.body1_r_16, textColor: .flintGray300)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layer.cornerRadius = bounds.height / 2
+    }
+    
+    override func rightViewRect(forBounds bounds: CGRect) -> CGRect {
+        var padding = super.rightViewRect(forBounds: bounds)
+        padding.origin.x -= 12
+        return padding
+    }
+    
+    // MARK: - Setup
+    
+    private func setUI() {
+        backgroundColor = .flintGray700
+        tintColor = .flintGray300
+        
+        spellCheckingType = .no
+        autocapitalizationType = .none
+        autocorrectionType = .no
+        smartDashesType = .no
+        smartQuotesType = .no
+        smartInsertDeleteType = .no
+        if #available(iOS 17.0, *) {
+            inlinePredictionType = .no
+        }
+    }
+    
+    private func setLayout() {
+        addLeftPadding(16)
+        
+        rightView = actionButton
+        rightViewMode = .always
+        
+        snp.makeConstraints {
+            $0.height.equalTo(44)
+        }
+    }
+    
+    private func setAction() {
+        actionButton.addAction(UIAction(handler: touchUpInsideActionButton(_:)), for: .touchUpInside)
+        
+        addAction(UIAction(handler: { [weak self] _ in
+            self?.actionButton.setImage(.icCancel, for: .normal)
+        }), for: .editingDidBegin)
+        addAction(UIAction(handler: { [weak self] _ in
+            self?.actionButton.setImage(.icSearch, for: .normal)
+        }), for: .editingDidEnd)
+    }
+    
+    // MARK: - Function
+    
+    private func touchUpInsideActionButton(_ action: UIAction) {
+        if isFirstResponder {
+            text = nil
+        } else {
+            searchAction?(text)
+        }
+    }
+}

--- a/FLINT/FLINT/Presentation/Common/Extensions/UITextField+Typography.swift
+++ b/FLINT/FLINT/Presentation/Common/Extensions/UITextField+Typography.swift
@@ -25,4 +25,15 @@ extension UITextField {
             attributedText = NSAttributedString(string: t, attributes: attrs)
         }
     }
+    
+    func applyPlaceholderFontStyle(
+        _ style: TypographyStyle,
+        textColor: UIColor? = nil,
+        alignment: NSTextAlignment = .natural
+    ) {
+        guard let placeholder else { return }
+        var attrs = style.attributes(textColor: textColor, alignment: alignment)
+        attrs[.foregroundColor] = textColor
+        attributedPlaceholder = NSAttributedString(string: placeholder, attributes: attrs)
+    }
 }


### PR DESCRIPTION
## 🎯 Related Issues
- #23 

## 📋 Description
- SearchTextField 구현 완료했습니다.

## 📱 Screenshot
<!-- 뷰 작업 시 SE 화면도 올리기 (컴포넌트 등은 선택) -->
| 기능/화면 | iPhone 17 |
|:---------:|:---------:|
| SearchTextField | <img src="https://github.com/user-attachments/assets/64350884-204c-4028-be89-277e7b80fc56" width="250"> |

이거 이미지 원래 영상에서는 파란색으로 잘 보이는데 gif 변환하니까 회색처럼 보이네여...
색은 밑에 캡쳐본에서 확인해주세여 ! !

<img src="https://github.com/user-attachments/assets/4efb0dac-36ba-47d1-bb67-4df3c39d4d6f" width="250">

## 💬 To Reviewers  
```swift
let searchTextField = SearchTextField(placeholder: "Placeholder 메세지입니당", searchAction: { text in
    print(text)
})
```

```swift
searchTextField.searchAction = { text in
    print(text)
}
```
search action은 위 방법 중 하나 선택해서 정의해서 사용하시면 됩니다.
수정할 점 보완할 점 있으면 말씀해주십숑 ! !