### PR TITLE
[feat] TextField & TextView 구현

### DIFF
--- a/FLINT/FLINT/Presentation/Common/Components/FlintTextField.swift
+++ b/FLINT/FLINT/Presentation/Common/Components/FlintTextField.swift
@@ -1,0 +1,100 @@
+//
+//  SearchTextField.swift
+//  FLINT
+//
+//  Created by 김호성 on 2026.01.08.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class FlintTextField: UITextField {
+    
+    // MARK: - Property
+    
+    var maxLength: Int?
+    var onLengthChanged: ((_ textLength: Int, _ maxLength: Int) -> Void)?
+    
+    // MARK: - Component
+    
+    private let lengthLabel = UILabel().then {
+        $0.textColor = .flintGray300
+    }
+    
+    // MARK: - Basic
+     
+    init(placeholder: String, maxLength: Int? = nil, showLength: Bool = false) {
+        self.maxLength = maxLength
+        super.init(frame: .zero)
+        
+        setUI()
+        setLayout()
+        
+        attributedText = .pretendard(.body1_r_16, text: text ?? "")
+        attributedPlaceholder = .pretendard(.body1_r_16, text: placeholder, color: .flintGray300)
+        
+        addAction(UIAction(handler: updateLengthLabel(_:)), for: .editingChanged)
+        lengthLabel.isHidden = !showLength || maxLength == nil
+        
+        onLengthChanged?(text?.count ?? 0, maxLength ?? 0)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func rightViewRect(forBounds bounds: CGRect) -> CGRect {
+        var padding = super.rightViewRect(forBounds: bounds)
+        padding.origin.x -= 12
+        return padding
+    }
+    
+    // MARK: - Setup
+    
+    private func setUI() {
+        backgroundColor = .flintGray800
+        tintColor = .flintGray300
+        textColor = .flintWhite
+        layer.cornerRadius = 8
+        
+        spellCheckingType = .no
+        autocapitalizationType = .none
+        autocorrectionType = .no
+        smartDashesType = .no
+        smartQuotesType = .no
+        smartInsertDeleteType = .no
+        if #available(iOS 17.0, *) {
+            inlinePredictionType = .no
+        }
+        
+        lengthLabel.attributedText = .pretendard(.body2_r_14, text: "\(text?.count ?? 0)/\(maxLength ?? 0)")
+    }
+    
+    private func setLayout() {
+        addLeftPadding(12)
+        
+        rightView = lengthLabel
+        rightViewMode = .always
+        
+        snp.makeConstraints {
+            $0.height.equalTo(40)
+        }
+    }
+    
+    private func updateLengthLabel(_ action: UIAction) {
+        guard let maxLength, let currentText = text else { return }
+        if currentText.count > maxLength {
+            let newText = currentText.prefix(maxLength)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                text = String(newText)
+                onLengthChanged?(text?.count ?? 0, maxLength)
+                lengthLabel.attributedText = .pretendard(.body2_r_14, text: "\(text?.count ?? 0)/\(maxLength)")
+            }
+        }
+        onLengthChanged?(text?.count ?? 0, maxLength)
+        lengthLabel.attributedText = .pretendard(.body2_r_14, text: "\(text?.count ?? 0)/\(maxLength)")
+    }
+}

--- a/FLINT/FLINT/Presentation/Common/Components/FlintTextView.swift
+++ b/FLINT/FLINT/Presentation/Common/Components/FlintTextView.swift
@@ -1,0 +1,118 @@
+//
+//  FlintTextView.swift
+//  FLINT
+//
+//  Created by 김호성 on 2026.01.13.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class FlintTextView: BaseView {
+    
+    // MARK: - Property
+    
+    var maxLength: Int?
+    var onLengthChanged: ((_ textLength: Int, _ maxLength: Int) -> Void)?
+    var placeholder: String {
+        didSet {
+            placeholderLabel.attributedText = .pretendard(.body1_m_16, text: placeholder, color: .flintGray300)
+        }
+    }
+    
+    // MARK: - Component
+    
+    private let placeholderLabel = UILabel().then {
+        $0.textColor = .flintGray300
+        $0.attributedText = .pretendard(.body1_m_16, text: "", color: .flintGray300)
+    }
+    
+    private let textView = UITextView().then {
+        $0.backgroundColor = .flintGray800
+        $0.tintColor = .flintGray300
+        $0.textColor = .flintWhite
+        
+        $0.font = .pretendard(.body1_m_16)
+        $0.attributedText = .pretendard(.body1_m_16, text: "")
+        
+        $0.textContainer.lineFragmentPadding = 0
+        $0.contentInset = .zero
+        // TEMP: 원래는 top: 10 이어야 하는데 system 기본 padding 때문인지 5 더해줘야 딱 맞음. 추후 해결책 강구해보겠음.
+//        $0.textContainerInset = .init(top: 10 + 5, left: 12, bottom: 10, right: 12)
+        $0.textContainerInset = .init(top: 10, left: 12, bottom: 10, right: 12)
+        $0.layer.cornerRadius = 8
+        
+        $0.spellCheckingType = .no
+        $0.autocapitalizationType = .none
+        $0.autocorrectionType = .no
+        $0.smartDashesType = .no
+        $0.smartQuotesType = .no
+        $0.smartInsertDeleteType = .no
+        if #available(iOS 17.0, *) {
+            $0.inlinePredictionType = .no
+        }
+        
+        $0.isScrollEnabled = false
+    }
+    
+    // MARK: - Basic
+     
+    init(placeholder: String, maxLength: Int? = nil) {
+        self.placeholder = placeholder
+        self.maxLength = maxLength
+        super.init(frame: .zero)
+        
+        placeholderLabel.attributedText = .pretendard(.body1_m_16, text: placeholder, color: .flintGray300)
+        textView.delegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    override func setUI() {
+        textView.attributedText = .pretendard(.body1_m_16, text: "")
+        setTypingAttributes()
+    }
+    
+    override func setHierarchy() {
+        addSubviews(textView, placeholderLabel)
+    }
+    
+    override func setLayout() {
+        textView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        placeholderLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(10)
+            $0.horizontalEdges.equalToSuperview().inset(12)
+        }
+    }
+    
+    // MARK: - Private Function
+    
+    private func setTypingAttributes() {
+        textView.typingAttributes = NSAttributedString.pretendard(.body1_m_16, text: " ", color: .flintWhite).attributes(at: 0, effectiveRange: nil)
+    }
+}
+
+extension FlintTextView: UITextViewDelegate {
+    func textViewDidChange(_ textView: UITextView) {
+        guard let maxLength, let currentText = textView.text else { return }
+        if currentText.count > maxLength {
+            let newText = currentText.prefix(maxLength)
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                textView.text = String(newText)
+                placeholderLabel.isHidden = !textView.text.isEmpty
+                onLengthChanged?(textView.text?.count ?? 0, maxLength)
+            }
+        }
+        placeholderLabel.isHidden = !textView.text.isEmpty
+        onLengthChanged?(textView.text?.count ?? 0, maxLength)
+    }
+}

--- a/FLINT/FLINT/Presentation/Common/Components/FlintTextView.swift
+++ b/FLINT/FLINT/Presentation/Common/Components/FlintTextView.swift
@@ -39,8 +39,6 @@ final class FlintTextView: BaseView {
         
         $0.textContainer.lineFragmentPadding = 0
         $0.contentInset = .zero
-        // TEMP: 원래는 top: 10 이어야 하는데 system 기본 padding 때문인지 5 더해줘야 딱 맞음. 추후 해결책 강구해보겠음.
-//        $0.textContainerInset = .init(top: 10 + 5, left: 12, bottom: 10, right: 12)
         $0.textContainerInset = .init(top: 10, left: 12, bottom: 10, right: 12)
         $0.layer.cornerRadius = 8
         
@@ -99,6 +97,8 @@ final class FlintTextView: BaseView {
         textView.typingAttributes = NSAttributedString.pretendard(.body1_m_16, text: " ", color: .flintWhite).attributes(at: 0, effectiveRange: nil)
     }
 }
+
+// MARK: - UITextViewDelegate
 
 extension FlintTextView: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {


### PR DESCRIPTION
## 🎯 Related Issues
- #51 

## 📋 Description
- 글자수 제한, TextView 높이 자동 조절 등 다 구현했습니다.
```swift
        rootView.nicknameTextField.onLengthChanged = { [weak self] textLength, maxLength in
            self?.rootView.nicknameTitleLabel.text = "\(textLength)/\(maxLength)"
        }
```
```swift
let nicknameTextField = FlintTextField(placeholder: "닉네임", maxLength: 8, showLength: true)
```

```swift
    private let textView = FlintTextView(placeholder: "작품 이름")

        textView.onLengthChanged = { [weak self] textLength, maxLength in
            self?.temp.text = "\(textLength)/\(maxLength)"
        }

        textView.snp.makeConstraints {
            $0.center.equalToSuperview()
            $0.width.equalTo(300)
            $0.height.greaterThanOrEqualTo(100)
        }
```

## 📱 Screenshot
<!-- 뷰 작업 시 SE 화면도 올리기 (컴포넌트 등은 선택) -->
| 기능/화면 | iPhone 15 Pro | iPhone SE |
|:---------:|:---------:|:---------:|
| TextField | <img src="https://github.com/user-attachments/assets/29fbc574-e41d-4b5e-9fa5-eadb9a588074" width="250"> |
| TextView | <img src="https://github.com/user-attachments/assets/63131591-0a56-45b5-838a-f8f4bc437c35" width="250"> |

## 💬 To Reviewers  
- 
