### PR TITLE
[feat] 프로필 뷰 구현

### DIFF
--- a/FLINT/FLINT/Presentation/Profile/PreferenceRankedChipTableViewCell.swift
+++ b/FLINT/FLINT/Presentation/Profile/PreferenceRankedChipTableViewCell.swift
@@ -1,0 +1,45 @@
+//
+//  PreferenceRankedChipTableViewCell.swift
+//  FLINT
+//
+//  Created by 진소은 on 1/20/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class PreferenceRankedChipTableViewCell: BaseTableViewCell {
+
+    private let chipView = PreferenceRankedChipView()
+
+    override func setStyle() {
+        contentView.backgroundColor = .flintBackground
+        selectionStyle = .none
+
+        preservesSuperviewLayoutMargins = false
+        layoutMargins = .zero
+        contentView.layoutMargins = .zero
+    }
+
+    override func setHierarchy() {
+        contentView.addSubview(chipView)
+    }
+
+    override func setLayout() {
+        chipView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(16)
+        }
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        chipView.configure(keywords: [])
+    }
+
+    func configure(keywords: [KeywordDTO]) {
+        chipView.configure(keywords: keywords)
+    }
+}

--- a/FLINT/FLINT/Presentation/Profile/ProfileHeaderTableViewCell.swift
+++ b/FLINT/FLINT/Presentation/Profile/ProfileHeaderTableViewCell.swift
@@ -1,0 +1,95 @@
+//
+//  ProfileHeaderTableViewCell.swift
+//  FLINT
+//
+//  Created by 진소은 on 1/19/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ProfileHeaderTableViewCell: BaseTableViewCell {
+    
+    // MARK: - Component
+    
+    private let profilebackgroundImageView = UIImageView().then {
+        $0.image = UIImage(resource: .imgBackgroundGradiantMiddle)
+        $0.contentMode = .scaleToFill
+    }
+    
+    private let profileImageView = UIImageView().then {
+        $0.image = UIImage(resource: .imgProfileGray)
+    }
+    
+    private let gradientView = GradientView().then {
+        $0.colors = [.flintSecondary600, .clear]
+        $0.locations = [0.0, 1.0]
+        $0.startPoint = CGPoint(x: 0.5, y: 0.0)
+        $0.endPoint = CGPoint(x: 0.5, y: 1.0)
+    }
+    
+    private let nameStack = UIStackView().then {
+        $0.alignment = .center
+        $0.axis = .horizontal
+        $0.spacing = 8
+    }
+    
+    private let nameLabel = UILabel().then {
+        $0.textColor = .white
+        $0.attributedText = .pretendard(.display2_m_28, text: "쏘나기")
+    }
+    
+    private let verificationBadge = UIImageView().then {
+        $0.image = UIImage(resource: .icQuilified)
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        verificationBadge.isHidden = false
+    }
+    
+    override func setHierarchy() {
+        contentView.backgroundColor = .flintBackground
+        contentView.addSubviews(profilebackgroundImageView, gradientView, profileImageView, nameStack)
+        nameStack.addArrangedSubviews(nameLabel, verificationBadge)
+    }
+    
+    override func setLayout() {
+        profilebackgroundImageView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(230)
+        }
+        
+        profileImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(13)
+            $0.bottom.equalTo(profilebackgroundImageView.snp.bottom).offset(34)
+            $0.size.equalTo(128)
+        }
+        
+        gradientView.snp.makeConstraints {
+            $0.top.equalTo(profilebackgroundImageView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(34)
+        }
+        
+        nameStack.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.top.equalTo(profileImageView.snp.bottom)
+            $0.height.equalTo(42)
+            
+            $0.bottom.equalToSuperview().inset(20)
+        }
+    }
+    
+    func configure(name: String, isVerified: Bool) {
+        nameLabel.attributedText = .pretendard(.display2_m_28, text: name)
+        verificationBadge.isHidden = !isVerified
+    }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    ProfileHeaderTableViewCell()
+}

--- a/FLINT/FLINT/Presentation/Profile/ProfileView.swift
+++ b/FLINT/FLINT/Presentation/Profile/ProfileView.swift
@@ -1,0 +1,45 @@
+//
+//  ProfileView.swift
+//  FLINT
+//
+//  Created by 진소은 on 1/19/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ProfileView: UIView {
+
+    let tableView = UITableView(frame: .zero, style: .plain).then {
+        $0.separatorStyle = .none
+        $0.showsVerticalScrollIndicator = false
+        $0.backgroundColor = .clear
+        $0.contentInsetAdjustmentBehavior = .never
+
+        $0.rowHeight = UITableView.automaticDimension
+        $0.estimatedRowHeight = 200
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setHierarchy()
+        setLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setHierarchy() {
+        backgroundColor = .flintBackground
+        addSubview(tableView)
+    }
+
+    private func setLayout() {
+        tableView.snp.makeConstraints {
+            $0.edges.equalTo(safeAreaLayoutGuide)
+        }
+    }
+}

--- a/FLINT/FLINT/Presentation/Profile/ProfileViewController.swift
+++ b/FLINT/FLINT/Presentation/Profile/ProfileViewController.swift
@@ -1,0 +1,289 @@
+//
+//  ProfileViewController.swift
+//  FLINT
+//
+//  Created by 진소은 on 1/19/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ProfileViewController: UIViewController {
+
+    private enum Row {
+        case profileHeader
+        case titleHeader(style: TitleHeaderTableViewCell.HeaderStyle,
+                         title: String,
+                         subtitle: String)
+        case preferenceChips(keywords: [KeywordDTO])
+        case collection(items: [MoreNoMoreCollectionItem])
+        case recentSaved(items: [RecentSavedContentItem])
+    }
+
+    private let tableView = UITableView(frame: .zero, style: .plain).then {
+        $0.separatorStyle = .none
+        $0.showsVerticalScrollIndicator = false
+        $0.backgroundColor = .flintBackground
+    }
+
+    private let dummyData: [KeywordDTO] = [
+        .init(color: .blue,   rank: 1, name: "영화",   percentage: 0, imageUrl: "https://d2z8tag0uwa5d5.cloudfront.net/keywords/logo/260119/1c5281f4-6101-401c-9a19-ff5cbe8d6313.png"),
+        .init(color: .pink,   rank: 2, name: "애니메이션",     percentage: 0, imageUrl: "https://d2z8tag0uwa5d5.cloudfront.net/keywords/logo/260119/e8c333c9-f7cd-4537-b25e-8ec7b53598a2.png"),
+        .init(color: .green,  rank: 3, name: "영화", percentage: 0, imageUrl: "https://picsum.photos/seed/3/80"),
+        .init(color: .orange, rank: 4, name: "공포",   percentage: 0, imageUrl: "https://picsum.photos/seed/4/80"),
+        .init(color: .yellow, rank: 5, name: "액션",   percentage: 0, imageUrl: "https://picsum.photos/seed/5/80"),
+        .init(color: .pink,   rank: 6, name: "성장",   percentage: 0, imageUrl: "https://picsum.photos/seed/6/80"),
+    ]
+    
+    private let moreNoMoreDummy: [MoreNoMoreCollectionItem] = [
+        MoreNoMoreCollectionItem(
+            id: UUID(),
+            image: UIImage(resource: .imgCollectionBg),
+            profileImage: UIImage(resource: .imgProfileGray),
+            title: "요즘 많이 보는 콘텐츠",
+            userName: "쏘나기"
+        ),
+        MoreNoMoreCollectionItem(
+            id: UUID(),
+            image: UIImage(resource: .imgCollectionBg),
+            profileImage: UIImage(resource: .imgProfileGray),
+            title: "취향 저격 영화 모음",
+            userName: "플린트"
+        ),
+        MoreNoMoreCollectionItem(
+            id: UUID(),
+            image: UIImage(resource: .imgCollectionBg),
+            profileImage: UIImage(resource: .imgProfileGray),
+            title: "혼자 보기 좋은 작품",
+            userName: "영화광"
+        )
+    ]
+    
+    private let recentSavedDummy: [RecentSavedContentItem] = [
+        RecentSavedContentItem(
+            posterImageName: "img_collection_bg",
+            title: "인터스텔라",
+            year: 2014,
+            availableOn: [.netflix, .watcha],
+            subscribedOn: [.netflix, .tving]
+        ),
+        RecentSavedContentItem(
+            posterImageName: "img_collection_bg",
+            title: "라라랜드",
+            year: 2016,
+            availableOn: [.watcha, .disneyPlus],
+            subscribedOn: [.watcha, .disneyPlus]
+        ),
+        RecentSavedContentItem(
+            posterImageName: "img_collection_bg",
+            title: "듄",
+            year: 2021,
+            availableOn: [.tving, .disneyPlus],
+            subscribedOn: [.tving]
+        ),
+        RecentSavedContentItem(
+            posterImageName: "img_collection_bg",
+            title: "기생충",
+            year: 2019,
+            availableOn: [.netflix],
+            subscribedOn: [.netflix, .watcha]
+        )
+    ]
+
+
+    private lazy var rows: [Row] = [
+        .profileHeader,
+        .titleHeader(style: .normal, title: "쏘나기님의 취향 키워드", subtitle: "쏘나기님이 관심있어하는 키워드예요"),
+        .preferenceChips(keywords: dummyData),
+        .titleHeader(style: .more, title: "쏘나기님의 컬렉션", subtitle: "쏘나기님이 생성한 컬렉션이에요"),
+        .collection(items: moreNoMoreDummy),
+        .titleHeader(style: .more, title: "저장한 컬렉션", subtitle: "쏘나기님이 저장한 컬렉션이에요"),
+        .collection(items: moreNoMoreDummy),
+        .titleHeader(style: .more, title: "저장한 작품", subtitle: "쏘나기님이 저장한 작품이에요"),
+        .recentSaved(items: recentSavedDummy)
+    ]
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupTableView()
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .flintBackground
+
+        view.addSubview(tableView)
+        tableView.snp.makeConstraints {
+            $0.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+
+    private func setupTableView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        tableView.register(
+            ProfileHeaderTableViewCell.self,
+            forCellReuseIdentifier: ProfileHeaderTableViewCell.reuseIdentifier
+        )
+
+        tableView.register(
+            TitleHeaderTableViewCell.self,
+            forCellReuseIdentifier: TitleHeaderTableViewCell.reuseIdentifier
+        )
+        
+        tableView.register(
+            PreferenceRankedChipTableViewCell.self, forCellReuseIdentifier: PreferenceRankedChipTableViewCell.reuseIdentifier
+        )
+        
+        tableView.register(
+            MoreNoMoreCollectionTableViewCell.self, forCellReuseIdentifier: MoreNoMoreCollectionTableViewCell.reuseIdentifier
+        )
+        
+        tableView.register(
+            RecentSavedContentTableViewCell.self, forCellReuseIdentifier: RecentSavedContentTableViewCell.reuseIdentifier
+        )
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension ProfileViewController: UITableViewDataSource {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return rows.count
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView,
+                   cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        switch rows[indexPath.section] {
+        case .profileHeader:
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: ProfileHeaderTableViewCell.reuseIdentifier,
+                for: indexPath
+            ) as? ProfileHeaderTableViewCell else {
+                return UITableViewCell()
+            }
+
+            cell.selectionStyle = .none
+            cell.configure(name: "쏘나기", isVerified: true)
+
+            return cell
+
+        case let .titleHeader(style, title, subtitle):
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: TitleHeaderTableViewCell.reuseIdentifier,
+                for: indexPath
+            ) as? TitleHeaderTableViewCell else {
+                return UITableViewCell()
+            }
+
+            cell.configure(style: style, title: title, subtitle: subtitle)
+
+            cell.onTapMore = { [weak self] in
+                guard let self else { return }
+                self.didTapMore(for: indexPath)
+            }
+
+            return cell
+            
+        case let .preferenceChips(keywords):
+            guard let cell = tableView.dequeueReusableCell(
+                withIdentifier: PreferenceRankedChipTableViewCell.reuseIdentifier,
+                for: indexPath
+            ) as? PreferenceRankedChipTableViewCell else { return UITableViewCell() }
+
+            cell.configure(keywords: keywords)
+            return cell
+        case let .collection(items):
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: MoreNoMoreCollectionTableViewCell.reuseIdentifier,
+                for: indexPath
+            ) as! MoreNoMoreCollectionTableViewCell
+
+            cell.configure(items: items)
+
+            cell.onSelectItem = { item in
+                print(item.title, item.userName)
+            }
+
+            return cell
+
+        case let .recentSaved(items):
+            let cell = tableView.dequeueReusableCell(
+                withIdentifier: RecentSavedContentTableViewCell.reuseIdentifier,
+                for: indexPath
+            ) as! RecentSavedContentTableViewCell
+
+            cell.configure(items: items)
+
+            cell.onTapItem = { item in
+                Log.d("최근 저장 작품 탭:", item)
+            }
+
+            return cell
+
+        }
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension ProfileViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return UIView()
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        switch rows[section] {
+            
+        case .profileHeader:
+            return 6
+        case .titleHeader:
+            return 0
+        case .preferenceChips:
+            return 48
+        case .collection:
+            return 24
+        case .recentSaved:
+            return 24
+        }
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch rows[indexPath.section] {
+        case .profileHeader:
+            break
+        case .titleHeader:
+            break
+        case .preferenceChips:
+            break
+        case .collection:
+            break
+        case .recentSaved:
+            break
+        }
+    }
+}
+
+// MARK: - Actions
+
+private extension ProfileViewController {
+
+    func didTapMore(for indexPath: IndexPath) {
+        switch rows[indexPath.section] {
+        case .titleHeader:
+            print("More tapped at row \(indexPath.row)")
+        default:
+            break
+        }
+    }
+}


### PR DESCRIPTION
## 🎯 Related Issues
- resolved #104 

## 📋 Description
- 프로필 뷰를 구현했습니다
- rows는 아래처럼 구성해두었습니다. 현재는 모두 목데이터로 넣어두었으며, 타이틀이나 데이터 변경은 API 연결 작업 진행하면서 함꼐 진행하도록 하겠습니다.
```swift
    private lazy var rows: [Row] = [
        .profileHeader,
        .titleHeader(style: .normal, title: "쏘나기님의 취향 키워드", subtitle: "쏘나기님이 관심있어하는 키워드예요"),
        .preferenceChips(keywords: dummyData),
        .titleHeader(style: .more, title: "쏘나기님의 컬렉션", subtitle: "쏘나기님이 생성한 컬렉션이에요"),
        .collection(items: moreNoMoreDummy),
        .titleHeader(style: .more, title: "저장한 컬렉션", subtitle: "쏘나기님이 저장한 컬렉션이에요"),
        .collection(items: moreNoMoreDummy),
        .titleHeader(style: .more, title: "저장한 작품", subtitle: "쏘나기님이 저장한 작품이에요"),
        .recentSaved(items: recentSavedDummy)
    ]
```

## 📱 Screenshot
<!-- 뷰 작업 시 SE 화면도 올리기 (컴포넌트 등은 선택) -->
| 기능/화면 | iPhone 15 Pro | iPhone SE |
|:---------:|:---------:|:---------:|
| 취향 키워드 3줄 | <img src="https://github.com/user-attachments/assets/261063f6-c2a2-4b0c-97ab-68b1a7cdc7ad" width="250"> | <img src="https://github.com/user-attachments/assets/52c1ea12-4192-42de-8b01-2b52bffa996c" width="250"> | 
| 취향 키워드 2줄 | <img src="https://github.com/user-attachments/assets/ff2439ad-1ae8-46f4-b5eb-c5c9db67847c" width="250"> | <img src="https://github.com/user-attachments/assets/0d4da44f-4fa5-4bff-acc7-e22978871520" width="250"> |

## 💬 To Reviewers  
- 사실 어려운 내용이 없어서... 그저 뷰조립.. 궁금한 부분 있으면 코멘트 남겨주십쇼
