### PR TITLE
[fix] addAction 순환참조

### DIFF
--- a/FLINT/Presentation/Sources/View/Component/FlintTextField.swift
+++ b/FLINT/Presentation/Sources/View/Component/FlintTextField.swift
@@ -35,7 +35,7 @@ public final class FlintTextField: UITextField {
         attributedText = .pretendard(.body1_r_16, text: text ?? "")
         attributedPlaceholder = .pretendard(.body1_r_16, text: placeholder, color: .flintGray300)
         
-        addAction(UIAction(handler: updateLengthLabel(_:)), for: .editingChanged)
+        addAction(UIAction(weak: self, handler: FlintTextField.updateLengthLabel(_:)), for: .editingChanged)
         lengthLabel.isHidden = !showLength || maxLength == nil
         
         onLengthChanged?(text?.count ?? 0, maxLength ?? 0)

--- a/FLINT/Presentation/Sources/View/Component/SearchTextField.swift
+++ b/FLINT/Presentation/Sources/View/Component/SearchTextField.swift
@@ -80,7 +80,7 @@ public final class SearchTextField: UITextField {
     }
     
     private func setAction() {
-        actionButton.addAction(UIAction(handler: touchUpInsideActionButton(_:)), for: .touchUpInside)
+        actionButton.addAction(UIAction(weak: self, handler: SearchTextField.touchUpInsideActionButton(_:)), for: .touchUpInside)
         
         addAction(UIAction(handler: { [weak self] _ in
             self?.actionButton.setImage(.icCancel, for: .normal)

--- a/FLINT/Presentation/Sources/View/Extension/UIAction+.swift
+++ b/FLINT/Presentation/Sources/View/Extension/UIAction+.swift
@@ -1,0 +1,20 @@
+//
+//  UIAction+.swift
+//  Presentation
+//
+//  Created by 루미씨티 on 4/14/26.
+//
+
+import UIKit
+
+extension UIAction {
+    public convenience init<T: AnyObject>(
+        weak target: T,
+        handler: @escaping @Sendable (T) -> @Sendable (UIAction) -> Void
+    ) {
+        self.init { [weak target] action in
+            guard let target else { return }
+            handler(target)(action)
+        }
+    }
+}

--- a/FLINT/Presentation/Sources/View/Scene/Onboarding/Nickname/NicknameView.swift
+++ b/FLINT/Presentation/Sources/View/Scene/Onboarding/Nickname/NicknameView.swift
@@ -65,7 +65,7 @@ public final class NicknameView: BaseView {
     public override init(frame: CGRect) {
         super.init(frame: frame)
         
-        nicknameTextField.addAction(UIAction(handler: nicknameTextFieldEditingChanged(_:)), for: .editingChanged)
+        nicknameTextField.addAction(UIAction(weak: self, handler: NicknameView.nicknameTextFieldEditingChanged(_:)), for: .editingChanged)
     }
     
     required init?(coder: NSCoder) {

--- a/FLINT/Presentation/Sources/ViewController/Scene/Explore/ExploreViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Explore/ExploreViewController.swift
@@ -120,7 +120,7 @@ extension ExploreViewController {
                 
             case .empty:
                 let cell = collectionView.dequeueReusableCell(ExploreEmptyCollectionViewCell.self, for: indexPath)
-                cell.createCollectionButton.addAction(UIAction(handler: pushCreateCollectionViewController(_:)), for: .touchUpInside)
+                cell.createCollectionButton.addAction(UIAction(weak: self, handler: ExploreViewController.pushCreateCollectionViewController(_:)), for: .touchUpInside)
                 return cell
             }
         })

--- a/FLINT/Presentation/Sources/ViewController/Scene/Login/LoginViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Login/LoginViewController.swift
@@ -35,7 +35,7 @@ public final class LoginViewController: BaseViewController<LoginView> {
     public override func viewDidLoad() {
         super.viewDidLoad()
         
-        rootView.kakaoButton.addAction(UIAction(handler: kakaoLogin(_:)), for: .touchUpInside)
+        rootView.kakaoButton.addAction(UIAction(weak: self, handler: LoginViewController.kakaoLogin(_:)), for: .touchUpInside)
     }
     
     public override func bind() {

--- a/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/ContentSelect/ContentSelectViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/ContentSelect/ContentSelectViewController.swift
@@ -83,7 +83,7 @@ public final class ContentSelectViewController: BaseViewController<ContentSelect
         rootView.layoutIfNeeded()
         rootView.contentCollectionView.contentOffset.y = -rootView.contentCollectionView.contentInset.top
         
-        rootView.nextButton.addAction(UIAction(handler: pushOttSelectViewController(_:)), for: .touchUpInside)
+        rootView.nextButton.addAction(UIAction(weak: self, handler: ContentSelectViewController.pushOttSelectViewController(_:)), for: .touchUpInside)
     }
     
     public override func bind() {

--- a/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/Done/OnboardingDoneViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/Done/OnboardingDoneViewController.swift
@@ -38,7 +38,7 @@ public final class OnboardingDoneViewController: BaseViewController<OnboardingDo
         super.viewDidLoad()
 
         setNavigationBar(.init(left: .back))
-        rootView.startButton.addAction(UIAction(handler: completeOnboarding(_:)), for: .touchUpInside)
+        rootView.startButton.addAction(UIAction(weak: self, handler: OnboardingDoneViewController.completeOnboarding(_:)), for: .touchUpInside)
     }
     
     public override func bind() {

--- a/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/Nickname/NicknameViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/Nickname/NicknameViewController.swift
@@ -81,9 +81,9 @@ public final class NicknameViewController: BaseViewController<NicknameView> {
     // MARK: - Private Function
     
     private func addActions() {
-        rootView.profileImageSettingView.settingButton.addAction(UIAction(handler: showProfileImageSettingAlert(_:)), for: .touchUpInside)
-        rootView.verifyButton.addAction(UIAction(handler: verifyNickname(_:)), for: .touchUpInside)
-        rootView.nextButton.addAction(UIAction(handler: nextButtonTapped(_:)), for: .touchUpInside)
+        rootView.profileImageSettingView.settingButton.addAction(UIAction(weak: self, handler: NicknameViewController.showProfileImageSettingAlert(_:)), for: .touchUpInside)
+        rootView.verifyButton.addAction(UIAction(weak: self, handler: NicknameViewController.verifyNickname(_:)), for: .touchUpInside)
+        rootView.nextButton.addAction(UIAction(weak: self, handler: NicknameViewController.nextButtonTapped(_:)), for: .touchUpInside)
     }
     
     private func showProfileImageSettingAlert(_ action: UIAction) {

--- a/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/OttSelect/OttSelectViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/OttSelect/OttSelectViewController.swift
@@ -44,7 +44,7 @@ public class OttSelectViewController: BaseViewController<OttSelectView> {
         rootView.titleLabel.attributedText = .pretendard(.display2_m_28, text: "얀비 님이 구독 중인 OTT 서비스를 알려주세요", lineBreakMode: .byWordWrapping, lineBreakStrategy: .hangulWordPriority)
         rootView.ottCollectionView.dataSource = self
         rootView.ottCollectionView.delegate = self
-        rootView.nextButton.addAction(UIAction(handler: pushOnboardingDoneViewController(_:)), for: .touchUpInside)
+        rootView.nextButton.addAction(UIAction(weak: self, handler: OttSelectViewController.pushOnboardingDoneViewController(_:)), for: .touchUpInside)
     }
     
     public override func bind() {


### PR DESCRIPTION
## 🎯 Related Issues
- #166 

## 📋 Description
```swift
extension UIAction {
    public convenience init<T: AnyObject>(
        weak target: T,
        handler: @escaping @Sendable (T) -> @Sendable (UIAction) -> Void
    ) {
        self.init { [weak target] action in
            guard let target else { return }
            handler(target)(action)
        }
    }
}
```
- function에서도 self capture되는데 그걸 그냥 클로저 인자로 전달해버려서 순환참조 생기는 것 위 코드로 해결했습니다.

## 💬 To Reviewers  
- 