### PR TITLE
[network] kakao login with account 구현

### DIFF
--- a/FLINT/Data/Sources/Networking/Extension/AnyPublisher+BaseResponse.swift
+++ b/FLINT/Data/Sources/Networking/Extension/AnyPublisher+BaseResponse.swift
@@ -16,10 +16,10 @@ import Domain
 import DTO
 
 public extension AnyPublisher where Output == Response, Failure == MoyaError {
-    func mapBaseResponseData<D: Codable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true) -> AnyPublisher<D, Error> {
+    func mapBaseResponseData<D: Codable>(_ type: D.Type, atKeyPath keyPath: String? = nil, using decoder: JSONDecoder = JSONDecoder(), failsOnEmptyData: Bool = true, filename: String = #file, line: Int = #line, funcName: String = #function) -> AnyPublisher<D, Error> {
         return map(BaseResponse<D>.self)
             .tryMap({ baseResponse in
-                Log.d(baseResponse)
+                Log.d(baseResponse, filename: filename, line: line, funcName: funcName)
                 guard (200..<300).contains(baseResponse.status) else {
                     throw NetworkError.httpStatusCode(baseResponse.serverError)
                 }

--- a/FLINT/FLINT/Application/SceneDelegate.swift
+++ b/FLINT/FLINT/Application/SceneDelegate.swift
@@ -22,9 +22,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         
-//        let viewController = diContainer.makeSplashViewController()
-//        let viewController = diContainer.makeNicknameViewController()
-        let viewController = diContainer.makeTabBarViewController()
+        let viewController = diContainer.makeSplashViewController()
         
         let navigationController = UINavigationController(rootViewController: viewController).configured({
             $0.navigationBar.isHidden = true

--- a/FLINT/Presentation/Sources/ViewModel/Scene/Login/LoginViewModel.swift
+++ b/FLINT/Presentation/Sources/ViewModel/Scene/Login/LoginViewModel.swift
@@ -36,29 +36,32 @@ public final class DefaultLoginViewModel: LoginViewModel {
     }
     
     public func kakaoLogin() {
-        guard UserApi.isKakaoTalkLoginAvailable() else {
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.loginWithKakaoTalk(completion: kakaoSocialVerify)
+        } else {
+            UserApi.shared.loginWithKakaoAccount(completion: kakaoSocialVerify)
+        }
+        
+    }
+    
+    private func kakaoSocialVerify(oauthToken: OAuthToken?, error: Error?) {
+        if let error = error {
+            Log.e(error)
             return
         }
-        UserApi.shared.loginWithKakaoTalk { [weak self] oauthToken, error in
-            guard let self else { return }
-            if let error = error {
-                Log.e(error)
-                return
-            }
-            if let accessToken = oauthToken?.accessToken {
-                socialVerifyUseCase(
-                    socialAuthCredential: SocialVerifyEntity(
-                        provider: .kakao,
-                        accessToken: accessToken
-                    )
+        if let accessToken = oauthToken?.accessToken {
+            socialVerifyUseCase(
+                socialAuthCredential: SocialVerifyEntity(
+                    provider: .kakao,
+                    accessToken: accessToken
                 )
-                .manageThread()
-                .sinkHandledCompletion { socialVerifyResultEntity in
-                    Log.d(socialVerifyResultEntity)
-                    self.socialVerifyResultEntity.send(socialVerifyResultEntity)
-                }
-                .store(in: &cancellables)
+            )
+            .manageThread()
+            .sinkHandledCompletion { socialVerifyResultEntity in
+                Log.d(socialVerifyResultEntity)
+                self.socialVerifyResultEntity.send(socialVerifyResultEntity)
             }
+            .store(in: &cancellables)
         }
     }
 }


### PR DESCRIPTION
## 🎯 Related Issues
- #185 

## 📋 Description
- kakao login with account 구현
- 기존에는 카카오톡 로그인만 됐는데 시뮬 테스트하기가 어려워 카카오 로그인 추가합니다

## 📱 Screenshot
<!-- 뷰 작업 시 SE 화면도 올리기 (컴포넌트 등은 선택) -->
| 기능/화면 | iPhone 15 Pro | iPhone SE |
|:---------:|:---------:|:---------:|
| A 기능 | <img src="" width="250"> | <img src="" width="250"> |
| B 기능 | <img src="" width="250"> | <img src="" width="250"> |

## 💬 To Reviewers  
- 할일 너무 많네유 ~~ 언제 다하냐잉 ?? ㅎㅎ,,,
