### PR TITLE
[hotfix] 취향키워드 재계산 동작 정상화

### DIFF
--- a/FLINT/Data/Sources/Networking/Service/UserService.swift
+++ b/FLINT/Data/Sources/Networking/Service/UserService.swift
@@ -84,9 +84,7 @@ public final class DefaultUserService: UserService {
     
     public func recalculateMyKeywords() -> AnyPublisher<Void, Error> {
         return userAPIProvider.requestPublisher(.recalculateMyKeywords)
-            .mapBaseResponseData(BlankData.self)
-            .map({ _ in })
-            .eraseToAnyPublisher()
+            .mapBaseResponseEmpty()
     }
     
     public func checkNickname(_ nickname: String) -> AnyPublisher<NicknameCheckDTO, Error> {

--- a/FLINT/Domain/Sources/Entity/User/UserProfileEntity.swift
+++ b/FLINT/Domain/Sources/Entity/User/UserProfileEntity.swift
@@ -16,7 +16,14 @@ public struct UserProfileEntity: Equatable {
     /// GET /users/me 에만 포함. 다른 유저 조회 시 nil.
     public let keywordRecalculatable: Bool?
 
-    public init(id: String, nickname: String, email: String, profileImageUrl: URL?, role: UserRole)  {
+    public init(
+        id: String,
+        nickname: String,
+        email: String,
+        profileImageUrl: URL?,
+        role: UserRole,
+        keywordRecalculatable: Bool? = nil
+    ) {
         self.id = id
         self.nickname = nickname
         self.email = email

--- a/FLINT/Presentation/Sources/ViewController/Scene/Profile/ProfileViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Profile/ProfileViewController.swift
@@ -42,7 +42,7 @@ public final class ProfileViewController: BaseViewController<ProfileView> {
         rootView.snp.remakeConstraints {
             $0.edges.equalToSuperview()
         }
-        
+
         let leftItem: NavLeftItem = profileViewModel.isMe ? .none : .back
         let rightItem: NavRightItem = profileViewModel.isMe ? .setting : .none
         setNavigationBar(
@@ -51,9 +51,14 @@ public final class ProfileViewController: BaseViewController<ProfileView> {
                 self?.didTapSetting()
             }
         )
-        
+
         setupTableView()
         bind()
+    }
+
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // 프로필 진입마다 최신 데이터 재fetch (취향키워드 재계산 가능 여부 포함)
         profileViewModel.load()
     }
 

--- a/FLINT/Presentation/Sources/ViewModel/Scene/Profile/ProfileViewModel.swift
+++ b/FLINT/Presentation/Sources/ViewModel/Scene/Profile/ProfileViewModel.swift
@@ -126,7 +126,7 @@ public final class ProfileViewModel {
                 self.rows = self.makeRows()
             }
             .store(in: &cancellables)
-        
+
         fetchCreatedCollectionsUseCase(for: target)
             .manageThread()
             .sink { completion in
@@ -179,11 +179,7 @@ public final class ProfileViewModel {
         isRefreshing = true
         rows = makeRows()
 
-        let target = self.target
-        let fetchKeywords = fetchKeywordsUseCase
-
         recalculateKeywordsUseCase()
-            .flatMap { _ in fetchKeywords(for: target) }
             .manageThread()
             .sink { [weak self] completion in
                 guard let self else { return }
@@ -191,14 +187,12 @@ public final class ProfileViewModel {
                 if case let .failure(error) = completion {
                     print("recalculateKeywords failed:", error)
                     self.canRefresh = false
+                    self.rows = self.makeRows()
                 }
-                self.rows = self.makeRows()
-            } receiveValue: { [weak self] keywords in
+            } receiveValue: { [weak self] _ in
                 guard let self else { return }
-                self.keywords = keywords
-                // 방금 재계산했으므로 이후 20개 새로 쌓일 때까지 재활성 불가
-                self.canRefresh = false
-                self.rows = self.makeRows()
+                self.isRefreshing = false
+                self.load()
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## 🎯 Related Issues
- #217 

## 📋 Description

취향키워드 재계산 로직에 문제가 있어 정상화 작업을 했습니다

  ### 재계산 API 응답 파싱
  - `UserService.recalculateMyKeywords`가 `mapBaseResponseData(BlankData.self)`로 파싱하고 있어, 서버가 `data: null`을 반환하는 응답에서 `NetworkError.noData` 에러가 발생하던 문제 → `mapBaseResponseEmpty()`로 교체 (status만 검사, body 무시)

  ### Entity init 복구
  - `UserProfileEntity.init`에 `keywordRecalculatable` 파라미터가 누락돼 있어
  `self.keywordRecalculatable = keywordRecalculatable`가 컴파일 안 되던 상태 → 파라미터 추가 (기본값 `nil`로 다른 caller 영향 없음)

  ### 프로필 진입마다 재로드
  - `ProfileViewController.viewWillAppear`에서 `profileViewModel.load()` 호출 → 진입할 때마다 프로필/키워드/컬렉션/컨텐츠 최신 상태 반영
  - 취향키워드 업데이트 버튼 활성/비활성 (`keywordRecalculatable`) 도 매 진입마다 서버 응답 기준으로 갱신

  ### 재계산 성공 후 뷰 재로드
  - `ProfileViewModel.refreshKeywords` 성공 시 개별 `fetchKeywords`만 호출하던 것을 `load()` 전체 재호출로 변경 → 재계산 직후 서버 상태로 keywords + `keywordRecalculatable` 모두 갱신 → `PreferenceRankedChipTableViewCell` / `KeywordGraphTableViewCell` 새 값으로 리렌더

## 💬 To Reviewers  
필드가 바뀐지 몰랏지 머야,,~
