### PR TITLE
[hotfix] #219 온보딩 작품 선택 크래시 및 설정 화면 중복 액션 수정

### DIFF
--- a/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/ContentSelect/ContentSelectViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Onboarding/ContentSelect/ContentSelectViewController.swift
@@ -190,7 +190,8 @@ extension ContentSelectViewController {
     
     public func contentCollectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard onboardingViewModel.selectedContents.value.count <= 6 else { return }
-        onboardingViewModel.clickContent(onboardingViewModel.contents.value[indexPath.item])
+        guard case let .content(content) = contentCollectionViewDataSource?.itemIdentifier(for: indexPath) else { return }
+        onboardingViewModel.clickContent(content)
     }
     
     @objc public func contentCollectionViewPanGesture(_ sender: UIPanGestureRecognizer) {

--- a/FLINT/Presentation/Sources/ViewController/Scene/Profile/CreatedCollectionListViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Profile/CreatedCollectionListViewController.swift
@@ -34,7 +34,6 @@ public final class CreatedCollectionListViewController: BaseViewController<Colle
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        bind()
         applyCount()
     }
 

--- a/FLINT/Presentation/Sources/ViewController/Scene/Profile/SavedCollectionListViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Profile/SavedCollectionListViewController.swift
@@ -34,7 +34,6 @@ public final class SavedCollectionListViewController: BaseViewController<Collect
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        bind()
         applyCount()
     }
 

--- a/FLINT/Presentation/Sources/ViewController/Scene/Profile/SavedFilmListViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Profile/SavedFilmListViewController.swift
@@ -34,7 +34,6 @@ public final class SavedFilmListViewController: BaseViewController<SavedFilmList
         super.viewDidLoad()
         setupTableView()
         setupSearch()
-        bind()
         viewModel.load()
     }
 

--- a/FLINT/Presentation/Sources/ViewController/Scene/Setting/SettingViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Setting/SettingViewController.swift
@@ -80,7 +80,6 @@ public final class SettingViewController: BaseViewController<SettingView> {
         ))
         setupTableView()
         setupActions()
-        bind()
     }
     
     // MARK: - Bind


### PR DESCRIPTION
## 🎯 Related Issues
- closed #219

## 📋 Description

### 온보딩 작품 선택 크래시
  - `ContentSelectViewController.didSelectItemAt`에서
  `onboardingViewModel.contents.value[indexPath.item]` 로 직접 인덱스 접근하고 있어 검색어 입력 등으로 `contents.value`가 필터링된 직후 사용자 탭이 이전 스냅샷 기준 indexPath로 들어오면 out-of-range로 `EXC_BREAKPOINT` 크래시가 발생
  - diffable data source의 `itemIdentifier(for:)`로 스냅샷 기준 아이템 조회하도록 변경 → 인덱스 계열 크래시 원천 차단

  ### 설정 화면 액션 중복 실행
  - `SettingViewController.viewDidLoad`에서 `super.viewDidLoad()`가 이미 내부적으로`bind()`를 호출하는데, 하위에서 `bind()`를 한 번 더 호출하고 있어 모든 output 구독이 2번 등록되던 상태
  - 결과: 탈퇴하기 화면 push가 두 번, 로그아웃 모달 두 번, 개인정보/이용약관 링크 두 번 열림 등 모든 액션이 중복 실행
  - 하위 `viewDidLoad`의 중복 `bind()` 호출 제거

## 💬 To Reviewers  
- 
