### PR TITLE
[hotfix] #223 타인 프로필 저장 컬렉션 리스트 미노출 및 텍스트 필드 확장 처리

### DIFF
--- a/FLINT/FLINT/Dependency/Factory/ViewController/SavedCollectionListViewControllerFactory+.swift
+++ b/FLINT/FLINT/Dependency/Factory/ViewController/SavedCollectionListViewControllerFactory+.swift
@@ -7,12 +7,13 @@
 
 import Foundation
 
+import Domain
 import Presentation
 
 extension SavedCollectionListViewControllerFactory where Self: SavedCollectionListViewModelFactory & ViewControllerFactory {
-    func makeSavedCollectionListViewController() -> SavedCollectionListViewController {
+    func makeSavedCollectionListViewController(target: UserTarget) -> SavedCollectionListViewController {
         return SavedCollectionListViewController(
-            viewModel: makeSavedCollectionListViewModel(),
+            viewModel: makeSavedCollectionListViewModel(target: target),
             viewControllerFactory: self
         )
     }

--- a/FLINT/FLINT/Dependency/Factory/ViewModel/SavedCollectionListViewModelFactory.swift
+++ b/FLINT/FLINT/Dependency/Factory/ViewModel/SavedCollectionListViewModelFactory.swift
@@ -7,17 +7,19 @@
 
 import Foundation
 
+import Domain
 import Presentation
 
 protocol SavedCollectionListViewModelFactory:
     FetchBookmarkedCollectionsUseCaseFactory &
     ToggleCollectionBookmarkUseCaseFactory {
-    func makeSavedCollectionListViewModel() -> SavedCollectionListViewModel
+    func makeSavedCollectionListViewModel(target: UserTarget) -> SavedCollectionListViewModel
 }
 
 extension SavedCollectionListViewModelFactory {
-    func makeSavedCollectionListViewModel() -> SavedCollectionListViewModel {
+    func makeSavedCollectionListViewModel(target: UserTarget) -> SavedCollectionListViewModel {
         return SavedCollectionListViewModel(
+            target: target,
             fetchBookmarkedCollectionsUseCase: makeFetchBookmarkedCollectionsUseCase(),
             toggleCollectionBookmarkUseCase: makeToggleCollectionBookmarkUseCase()
         )

--- a/FLINT/Presentation/Sources/ViewController/Scene/CreateCollection/CreateCollectionView/CreateCollectionViewController+TableView.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/CreateCollection/CreateCollectionView/CreateCollectionViewController+TableView.swift
@@ -94,6 +94,8 @@ extension CreateCollectionViewController: UITableViewDataSource {
                     guard let self else { return }
                     self.collectionDescriptionText = text
                     self.updateCreatePayload()
+                    self.rootView.tableView.beginUpdates()
+                    self.rootView.tableView.endUpdates()
                 }
                 cell.setText(collectionDescriptionText)
                 return cell
@@ -177,6 +179,8 @@ extension CreateCollectionViewController: UITableViewDataSource {
                     if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         cell.setError(false)
                     }
+                    self.rootView.tableView.beginUpdates()
+                    self.rootView.tableView.endUpdates()
                 }
 
                 cell.onTapAddPhoto = { [weak self, weak cell] in

--- a/FLINT/Presentation/Sources/ViewController/Scene/CreateCollection/CreateCollectionView/CreateCollectionViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/CreateCollection/CreateCollectionView/CreateCollectionViewController.swift
@@ -114,6 +114,7 @@ public final class CreateCollectionViewController: BaseViewController<CreateColl
         setTableView()
         registerCells()
         bindViewModel()
+        hideKeyboardWhenTappedAround(activeOnAction: false)
     }
 
     public override func viewDidLayoutSubviews() {

--- a/FLINT/Presentation/Sources/ViewController/Scene/Profile/ProfileViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Profile/ProfileViewController.swift
@@ -116,7 +116,7 @@ public final class ProfileViewController: BaseViewController<ProfileView> {
 
         switch nextRow {
         case .savedCollections:
-            let vc = factory.makeSavedCollectionListViewController()
+            let vc = factory.makeSavedCollectionListViewController(target: profileViewModel.target)
             navigationController?.pushViewController(vc, animated: true)
         case .myCollections:
             let vc = factory.makeCreatedCollectionListViewController(target: profileViewModel.target)

--- a/FLINT/Presentation/Sources/ViewController/Scene/Profile/SavedCollectionListViewController.swift
+++ b/FLINT/Presentation/Sources/ViewController/Scene/Profile/SavedCollectionListViewController.swift
@@ -13,7 +13,13 @@ import ViewModel
 import Domain
 
 public protocol SavedCollectionListViewControllerFactory {
-    func makeSavedCollectionListViewController() -> SavedCollectionListViewController
+    func makeSavedCollectionListViewController(target: UserTarget) -> SavedCollectionListViewController
+}
+
+public extension SavedCollectionListViewControllerFactory {
+    func makeSavedCollectionListViewController() -> SavedCollectionListViewController {
+        makeSavedCollectionListViewController(target: .me)
+    }
 }
 
 public final class SavedCollectionListViewController: BaseViewController<CollectionFolderListView> {

--- a/FLINT/Presentation/Sources/ViewModel/Scene/Profile/SavedCollectionListViewModel.swift
+++ b/FLINT/Presentation/Sources/ViewModel/Scene/Profile/SavedCollectionListViewModel.swift
@@ -16,20 +16,23 @@ public final class SavedCollectionListViewModel {
     @Published public private(set) var items: [CollectionEntity] = []
 
     // MARK: - Dependency
+    private let target: UserTarget
     private let fetchBookmarkedCollectionsUseCase: FetchBookmarkedCollectionsUseCase
     private let toggleCollectionBookmarkUseCase: ToggleCollectionBookmarkUseCase
     private var cancellables = Set<AnyCancellable>()
 
     public init(
+        target: UserTarget,
         fetchBookmarkedCollectionsUseCase: FetchBookmarkedCollectionsUseCase,
         toggleCollectionBookmarkUseCase: ToggleCollectionBookmarkUseCase
     ) {
+        self.target = target
         self.fetchBookmarkedCollectionsUseCase = fetchBookmarkedCollectionsUseCase
         self.toggleCollectionBookmarkUseCase = toggleCollectionBookmarkUseCase
     }
 
     public func load() {
-        fetchBookmarkedCollectionsUseCase(for: .me)
+        fetchBookmarkedCollectionsUseCase(for: target)
             .receive(on: DispatchQueue.main)
             .sink { completion in
                 if case let .failure(error) = completion {


### PR DESCRIPTION
## 🎯 Related Issues
- close #223

## 📋 Description

  ### 타인 프로필 저장 컬렉션 리스트 미노출
  - `SavedCollectionListViewModel`이 `.me`로 하드코딩돼 타인 프로필에서도 내 저장 컬렉션을 조회하던 문제
  - VM/Factory/Protocol에 `target: UserTarget` 파라미터 추가, `ProfileViewController.didTapMore`에서 `profileViewModel.target` 전달

  ### 컬렉션 생성/수정 텍스트 필드 자동 확장
  - 컬렉션 소개, 작품 소개 필드가 줄바꿈되어도 셀 높이가 그대로라 텍스트가 잘리던 문제
  - `onChange` 콜백에서 `beginUpdates/endUpdates` 호출로 row 높이 재계산

  ### 컬렉션 생성/수정 텍스트 필드 외부 탭 포커스 해제
  - `hideKeyboardWhenTappedAround(activeOnAction: false)` 적용
  - UIControl 탭은 액션 정상 처리하며 키보드만 내려감
